### PR TITLE
Feature/issue#22

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 
 # Salesforce cache
 .sfdx/
+.sf/
 .localdevserver/
 
 # LWC VSCode autocomplete

--- a/config/project-scratch-def.json
+++ b/config/project-scratch-def.json
@@ -6,11 +6,6 @@
     "lightningExperienceSettings": {
       "enableS1DesktopEnabled": true
     },
-    "securitySettings": {
-      "passwordPolicies": {
-        "enableSetPasswordInApi": true
-      }
-    },
     "mobileSettings": {
       "enableS1EncryptedStoragePref2": false
     }

--- a/force-app/main/default/objects/Security_Health_Check_Risk__c/fields/OrgValue__c.field-meta.xml
+++ b/force-app/main/default/objects/Security_Health_Check_Risk__c/fields/OrgValue__c.field-meta.xml
@@ -4,7 +4,7 @@
     <deprecated>false</deprecated>
     <externalId>false</externalId>
     <label>OrgValue</label>
-    <length>100</length>
+    <length>150</length>
     <required>false</required>
     <trackTrending>false</trackTrending>
     <type>Text</type>


### PR DESCRIPTION
Fix for: https://github.com/SalesforceLabs/MultiOrgSecuritySummary/issues/22

Simply extending the field size was enough to accommodate the value.
While testing noticed that the size of the value is dependent of the language. In English the text was too long, in dutch it was just under 100 characters.

Also added some minor changes to the project files to accommodate for SF cli folder and Org Setting changes.
![image](https://github.com/user-attachments/assets/ce78d969-128c-4a76-abb5-00586e1cd51f)
